### PR TITLE
feat: Offline Grundlayout implementieren (#11)

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Offline – WebEng2 Map App</title>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        font-family: Inter, system-ui, sans-serif;
+        background: #f5f7fb;
+        color: #20232a;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+      }
+
+      .container {
+        text-align: center;
+        padding: 2rem;
+        max-width: 400px;
+      }
+
+      .icon {
+        font-size: 4rem;
+        margin-bottom: 1rem;
+      }
+
+      h1 {
+        font-size: 1.5rem;
+        margin: 0 0 0.75rem;
+      }
+
+      p {
+        color: #64748b;
+        margin: 0 0 1.5rem;
+        line-height: 1.6;
+      }
+
+      button {
+        padding: 0.75rem 1.5rem;
+        background: #2563eb;
+        color: white;
+        border: none;
+        border-radius: 0.5rem;
+        font-size: 1rem;
+        cursor: pointer;
+      }
+
+      button:hover {
+        background: #1d4ed8;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="icon">📡</div>
+      <h1>Keine Internetverbindung</h1>
+      <p>
+        Die App konnte nicht geladen werden. Bitte prüfe deine
+        Internetverbindung und versuche es erneut.
+      </p>
+      <button onclick="location.reload()">Erneut versuchen</button>
+    </div>
+  </body>
+</html>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,9 +1,69 @@
-const CACHE_NAME = 'webeng2-v1';
+const CACHE_NAME = 'webeng2-v2';
 
-self.addEventListener('install', () => {
+const APP_SHELL = [
+  '/',
+  '/index.html',
+  '/offline.html',
+  '/manifest.json',
+  '/img/Icon.png',
+  '/img/Icon.jpeg',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(APP_SHELL))
+  );
   self.skipWaiting();
 });
 
 self.addEventListener('activate', (event) => {
-  event.waitUntil(clients.claim());
+  event.waitUntil(
+    caches.keys()
+      .then((keys) => Promise.all(
+        keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key))
+      ))
+      .then(() => clients.claim())
+  );
 });
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  // APIs nie cachen — immer frische Daten holen
+  if (url.hostname.includes('nominatim') || url.hostname.includes('wikipedia')) {
+    return;
+  }
+
+  // Map-Tiles: Cache-First (Tiles ändern sich selten, spart Bandbreite offline)
+  if (url.hostname.includes('tile.openstreetmap.org')) {
+    event.respondWith(cacheFirst(request));
+    return;
+  }
+
+  // Gleiche Origin (App-Shell + Vite-Bundles): Cache-First mit Runtime-Caching
+  if (url.origin === self.location.origin) {
+    event.respondWith(cacheFirst(request));
+  }
+});
+
+async function cacheFirst(request) {
+  const cached = await caches.match(request);
+  if (cached) return cached;
+
+  try {
+    const response = await fetch(request);
+    if (response.ok) {
+      const cache = await caches.open(CACHE_NAME);
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch {
+    // Netzwerk nicht erreichbar — bei Navigation offline.html ausliefern
+    if (request.mode === 'navigate') {
+      const fallback = await caches.match('/offline.html');
+      if (fallback) return fallback;
+    }
+    return Response.error();
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { MapContainer, TileLayer } from "react-leaflet";
 import "leaflet/dist/leaflet.css";
 import Map from "./components/Map";
+import OfflineBanner from "./components/OfflineBanner";
 
 function App() {
   const [items, setItems] = useState(['Erstes Element', 'Zweites Element']);
@@ -21,6 +22,7 @@ function App() {
 
   return (
     <div className="app">
+      <OfflineBanner />
       <header className="app-header">
         <h1>React MVP</h1>
         <p>Ein einfacher Start für dein WebEng2-MVP.</p>

--- a/src/components/OfflineBanner.jsx
+++ b/src/components/OfflineBanner.jsx
@@ -1,0 +1,26 @@
+import { useState, useEffect } from 'react';
+
+export default function OfflineBanner() {
+  const [isOffline, setIsOffline] = useState(!navigator.onLine);
+
+  useEffect(() => {
+    const goOffline = () => setIsOffline(true);
+    const goOnline  = () => setIsOffline(false);
+
+    window.addEventListener('offline', goOffline);
+    window.addEventListener('online',  goOnline);
+
+    return () => {
+      window.removeEventListener('offline', goOffline);
+      window.removeEventListener('online',  goOnline);
+    };
+  }, []);
+
+  if (!isOffline) return null;
+
+  return (
+    <div className="offline-banner" role="status" aria-live="polite">
+      📡 Keine Internetverbindung – die App läuft im Offline-Modus
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -94,3 +94,15 @@ body {
   text-decoration: none;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);
 }
+
+.offline-banner {
+  background: #fef08a;
+  color: #713f12;
+  text-align: center;
+  padding: 0.6rem 1rem;
+  border-radius: 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  margin-bottom: 1rem;
+  border: 1px solid #fde047;
+}


### PR DESCRIPTION
- offline.html: statische Fallback-Seite bei fehlendem Netzwerk
- sw.js: offline.html in APP_SHELL, try/catch in cacheFirst(), Navigations-Requests erhalten offline.html als Fallback, CACHE_NAME auf v2 erhöht
- OfflineBanner.jsx: React-Komponente mit online/offline-Events
- App.jsx: OfflineBanner eingebunden
- index.css: Styles für den Offline-Banner