### PR TITLE
feat: Fahrroute visualisieren (#22)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,6 +37,11 @@ function App() {
     setSubmittedSearch(trimmed);
   };
 
+  const showLocationError = (message) => {
+    setLocationError(message);
+    setTimeout(() => setLocationError(""), 4000);
+  };
+
   const handleLocateUser = () => {
   if (!navigator.geolocation) {
     showLocationError("Geolocation wird von diesem Browser nicht unterstützt.");
@@ -140,15 +145,15 @@ function App() {
               
               {routeLoading && (
                 <p className="route-info">
-                  Route wird berechnet...
+                  Route wird berechnet…
                 </p>
               )}
 
-              {routeInfo && (
-                <p className="route-info">
-                  Entfernung: {routeInfo.distanceKm} km<br />
-                  Fahrzeit: {routeInfo.durationMin} Minuten
-                </p>
+              {routeInfo && !routeLoading && (
+                <div className="route-info">
+                  <strong>Fahrradroute</strong>
+                  🚴 {routeInfo.distanceKm} km &nbsp;·&nbsp; ⏱ {routeInfo.durationMin} Min.
+                </div>
               )}
 
               {routeError && (
@@ -184,6 +189,7 @@ function App() {
               setRouteInfo={setRouteInfo}
               setRouteError={setRouteError}
               setRouteLoading={setRouteLoading}
+              routeInfo={routeInfo}
             />
           </div>
         </Page>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -151,8 +151,9 @@ function App() {
 
               {routeInfo && !routeLoading && (
                 <div className="route-info">
-                  <strong>Fahrradroute</strong>
-                  🚴 {routeInfo.distanceKm} km &nbsp;·&nbsp; ⏱ {routeInfo.durationMin} Min.
+                  <strong>Route</strong>
+                  <span className="route-places">{routeInfo.from} → {routeInfo.to}</span>
+                  <span className="route-stats">{routeInfo.distanceKm} km &nbsp;·&nbsp; {routeInfo.durationMin} Min.</span>
                 </div>
               )}
 

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -33,14 +33,7 @@ const startIcon = L.divIcon({
     border-radius: 50%;
     border: 3px solid white;
     box-shadow: 0 2px 8px rgba(0,0,0,0.4);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: white;
-    font-weight: 700;
-    font-size: 13px;
-    font-family: sans-serif;
-  ">A</div>`,
+  "></div>`,
   iconSize: [30, 30],
   iconAnchor: [15, 15],
   popupAnchor: [0, -18],
@@ -57,16 +50,7 @@ const targetIcon = L.divIcon({
     transform: rotate(-45deg);
     border: 3px solid white;
     box-shadow: 0 2px 8px rgba(0,0,0,0.4);
-  "><span style="
-    display: block;
-    transform: rotate(45deg);
-    color: white;
-    font-weight: 700;
-    font-size: 13px;
-    font-family: sans-serif;
-    text-align: center;
-    line-height: 24px;
-  ">B</span></div>`,
+  "></div>`,
   iconSize: [30, 30],
   iconAnchor: [8, 30],
   popupAnchor: [7, -32],
@@ -96,11 +80,11 @@ function MapClickHandler({
       }
 
       try {
-        const name = await fetchPlaceName(e.latlng.lat, e.latlng.lng);
+        const { displayName, searchTerm } = await fetchLocationInfo(e.latlng.lat, e.latlng.lng);
         if (requestId.current !== currentId) return;
-        setPlaceName(name);
+        setPlaceName(displayName);
 
-        const wiki = await fetchWikipediaInfo(name);
+        const wiki = await fetchWikipediaInfo(searchTerm);
         if (requestId.current !== currentId) return;
         setWikiInfo(wiki ?? "not_found");
       } catch (error) {
@@ -159,13 +143,17 @@ function SearchPlaceHandler({
         }
 
         const coords = [result.lat, result.lon];
+        const parts = result.displayName.split(",");
+        const shortName = parts.slice(0, 2).join(",").trim();
+        const wikiTerm = parts[0].trim();
+
         setTargetPosition(coords);
-        setPlaceName(result.displayName);
+        setPlaceName(shortName);
         setWikiInfo("loading");
         onSearchError?.("");
         map.setView(coords, 14);
 
-        const wiki = await fetchWikipediaInfo(result.displayName);
+        const wiki = await fetchWikipediaInfo(wikiTerm);
         if (requestId.current !== currentId) return;
         setWikiInfo(wiki ?? "not_found");
       } catch (error) {
@@ -190,6 +178,7 @@ function RoutingMachine({
   setRouteInfo,
   setRouteError,
   setRouteLoading,
+  targetPlaceName,
 }) {
   const map = useMap();
   const routingControlRef = useRef(null);
@@ -223,8 +212,8 @@ function RoutingMachine({
         L.latLng(targetPosition[0], targetPosition[1]),
       ],
       router: L.Routing.osrmv1({
-        serviceUrl: "https://routing.openstreetmap.de/routed-bike/route/v1",
-        profile: "bike",
+        serviceUrl: "https://routing.openstreetmap.de/routed-car/route/v1",
+        profile: "car",
       }),
       // Eigene Marker übernehmen — LRM-Waypoint-Marker deaktivieren
       createMarker: () => null,
@@ -249,6 +238,8 @@ function RoutingMachine({
       setRouteInfo({
         distanceKm: (route.summary.totalDistance / 1000).toFixed(1),
         durationMin: Math.round(route.summary.totalTime / 60),
+        from: "Dein Standort",
+        to: targetPlaceName || "Ziel",
       });
       setRouteLoading(false);
       setRouteError("");
@@ -319,7 +310,7 @@ async function fetchWikipediaInfo(placeName) {
   };
 }
 
-async function fetchPlaceName(lat, lon) {
+async function fetchLocationInfo(lat, lon) {
   const url =
     `https://nominatim.openstreetmap.org/reverse?` +
     `lat=${lat}&lon=${lon}&format=json&addressdetails=1`;
@@ -329,16 +320,25 @@ async function fetchPlaceName(lat, lon) {
   });
 
   const data = await response.json();
+  const addr = data.address || {};
 
-  return (
-    data.address?.city ||
-    data.address?.town ||
-    data.address?.village ||
-    data.address?.municipality ||
-    data.address?.county ||
-    data.display_name ||
-    "Unbekannter Ort"
-  );
+  const city =
+    addr.city || addr.town || addr.village || addr.municipality || addr.county || "";
+  const road = addr.road;
+  const houseNumber = addr.house_number;
+
+  let displayName;
+  if (road) {
+    const street = houseNumber ? `${road} ${houseNumber}` : road;
+    displayName = city ? `${street}, ${city}` : street;
+  } else {
+    displayName = city || data.display_name || "Unbekannter Ort";
+  }
+
+  return {
+    displayName,
+    searchTerm: city || road || data.display_name?.split(",")[0]?.trim() || "Unbekannter Ort",
+  };
 }
 
 async function fetchCoordinatesForPlace(placeName) {
@@ -404,11 +404,11 @@ export default function Map({
 
     async function loadLocationInfo() {
       try {
-        const name = await fetchPlaceName(userPosition[0], userPosition[1]);
+        const { displayName, searchTerm } = await fetchLocationInfo(userPosition[0], userPosition[1]);
         if (requestId.current !== currentId) return;
-        setPlaceName(name);
+        setPlaceName(displayName);
 
-        const wiki = await fetchWikipediaInfo(name);
+        const wiki = await fetchWikipediaInfo(searchTerm);
         if (requestId.current !== currentId) return;
         setWikiInfo(wiki ?? "not_found");
       } catch {
@@ -420,6 +420,17 @@ export default function Map({
 
     loadLocationInfo();
   }, [userPosition]);
+
+  // Routeninfo-Banner aktualisieren sobald Ortsname aufgelöst wird
+  useEffect(() => {
+    if (
+      !placeName ||
+      placeName === "Ort wird geladen..." ||
+      placeName === "Kein Internet" ||
+      placeName === "Ort konnte nicht geladen werden"
+    ) return;
+    setRouteInfo((prev) => (prev ? { ...prev, to: placeName } : null));
+  }, [placeName]);
 
   // Route auto-aktualisieren wenn neues Ziel gewählt und Route bereits aktiv
   useEffect(() => {
@@ -460,6 +471,7 @@ export default function Map({
           setRouteInfo={setRouteInfo}
           setRouteError={setRouteError}
           setRouteLoading={setRouteLoading}
+          targetPlaceName={placeName}
         />
 
         {/* Grüner A-Marker an der Startposition (nur wenn Route aktiv) */}

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -472,7 +472,7 @@ export default function Map({
         {targetPosition && (
           <Marker
             position={targetPosition}
-            icon={routeInfo ? targetIcon : undefined}
+            icon={targetIcon}
             ref={markerRef}
             eventHandlers={{
               add: (e) => e.target.openPopup(),

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -23,6 +23,54 @@ L.Icon.Default.mergeOptions({
     "https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png",
 });
 
+// Grüner Start-Marker (A)
+const startIcon = L.divIcon({
+  className: "",
+  html: `<div style="
+    background: #22c55e;
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    border: 3px solid white;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-weight: 700;
+    font-size: 13px;
+    font-family: sans-serif;
+  ">A</div>`,
+  iconSize: [30, 30],
+  iconAnchor: [15, 15],
+  popupAnchor: [0, -18],
+});
+
+// Roter Ziel-Marker (B)
+const targetIcon = L.divIcon({
+  className: "",
+  html: `<div style="
+    background: #ef4444;
+    width: 30px;
+    height: 30px;
+    border-radius: 50% 50% 50% 0;
+    transform: rotate(-45deg);
+    border: 3px solid white;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.4);
+  "><span style="
+    display: block;
+    transform: rotate(45deg);
+    color: white;
+    font-weight: 700;
+    font-size: 13px;
+    font-family: sans-serif;
+    text-align: center;
+    line-height: 24px;
+  ">B</span></div>`,
+  iconSize: [30, 30],
+  iconAnchor: [8, 30],
+  popupAnchor: [7, -32],
+});
 
 function MapClickHandler({
   setTargetPosition,
@@ -49,19 +97,14 @@ function MapClickHandler({
 
       try {
         const name = await fetchPlaceName(e.latlng.lat, e.latlng.lng);
-
         if (requestId.current !== currentId) return;
-
         setPlaceName(name);
 
         const wiki = await fetchWikipediaInfo(name);
-
         if (requestId.current !== currentId) return;
-
         setWikiInfo(wiki ?? "not_found");
       } catch (error) {
         if (requestId.current !== currentId) return;
-
         console.error("Reverse Geocoding fehlgeschlagen:", error);
         setPlaceName("Ort konnte nicht geladen werden");
         setWikiInfo("error");
@@ -108,7 +151,6 @@ function SearchPlaceHandler({
 
       try {
         const result = await fetchCoordinatesForPlace(searchPlace);
-
         if (requestId.current !== currentId) return;
 
         if (!result) {
@@ -117,24 +159,17 @@ function SearchPlaceHandler({
         }
 
         const coords = [result.lat, result.lon];
-
         setTargetPosition(coords);
         setPlaceName(result.displayName);
         setWikiInfo("loading");
         onSearchError?.("");
-
         map.setView(coords, 14);
 
         const wiki = await fetchWikipediaInfo(result.displayName);
-
         if (requestId.current !== currentId) return;
-
         setWikiInfo(wiki ?? "not_found");
-
-        console.log("Ort über Suche gefunden:", result);
       } catch (error) {
         if (requestId.current !== currentId) return;
-
         console.error("Ortssuche fehlgeschlagen:", error);
         onSearchError?.("Ortssuche konnte nicht ausgeführt werden.");
         setWikiInfo("error");
@@ -145,93 +180,6 @@ function SearchPlaceHandler({
   }, [searchPlace]);
 
   return null;
-}
-
-async function fetchWikipediaInfo(placeName) {
-  const searchTerm = placeName.split(",")[0].trim();
-
-  const url =
-    `https://de.wikipedia.org/w/api.php?action=query` +
-    `&prop=extracts&exintro=true&explaintext=true&redirects=1` +
-    `&titles=${encodeURIComponent(searchTerm)}&format=json&origin=*`;
-
-  const response = await fetch(url);
-  const data = await response.json();
-
-  const pages = data.query?.pages;
-  if (!pages) return null;
-
-  const page = Object.values(pages)[0];
-
-  if (page.missing !== undefined || page.pageid === undefined) return null;
-
-  const extract = page.extract?.trim();
-  if (!extract) return null;
-
-  if (
-    extract.startsWith(searchTerm + " steht für") ||
-    extract.includes("Begriffsklärung")
-  ) {
-    return null;
-  }
-
-  const shortExtract =
-    extract.length > 250 ? extract.slice(0, 250).trimEnd() + " …" : extract;
-
-  return {
-    title: page.title,
-    extract: shortExtract,
-    url: `https://de.wikipedia.org/wiki/${encodeURIComponent(page.title)}`,
-  };
-}
-
-async function fetchPlaceName(lat, lon) {
-  const url =
-    `https://nominatim.openstreetmap.org/reverse?` +
-    `lat=${lat}&lon=${lon}&format=json&addressdetails=1`;
-
-  const response = await fetch(url, {
-    headers: {
-      "Accept-Language": "de",
-    },
-  });
-
-  const data = await response.json();
-
-  return (
-    data.address?.city ||
-    data.address?.town ||
-    data.address?.village ||
-    data.address?.municipality ||
-    data.address?.county ||
-    data.display_name ||
-    "Unbekannter Ort"
-  );
-}
-
-async function fetchCoordinatesForPlace(placeName) {
-  const url =
-    `https://nominatim.openstreetmap.org/search?` +
-    `q=${encodeURIComponent(placeName)}` +
-    `&format=json&limit=1&addressdetails=1`;
-
-  const response = await fetch(url, {
-    headers: {
-      "Accept-Language": "de",
-    },
-  });
-
-  const data = await response.json();
-
-  if (!data || data.length === 0) {
-    return null;
-  }
-
-  return {
-    lat: Number(data[0].lat),
-    lon: Number(data[0].lon),
-    displayName: data[0].display_name,
-  };
 }
 
 function RoutingMachine({
@@ -263,6 +211,7 @@ function RoutingMachine({
       return;
     }
 
+    // Alte Route entfernen
     if (routingControlRef.current) {
       map.removeControl(routingControlRef.current);
       routingControlRef.current = null;
@@ -277,6 +226,17 @@ function RoutingMachine({
         serviceUrl: "https://routing.openstreetmap.de/routed-bike/route/v1",
         profile: "bike",
       }),
+      // Eigene Marker übernehmen — LRM-Waypoint-Marker deaktivieren
+      createMarker: () => null,
+      // Blaue Route mit Outline für gute Sichtbarkeit
+      lineOptions: {
+        styles: [
+          { color: "#1e40af", weight: 9, opacity: 0.25 },
+          { color: "#3b82f6", weight: 5, opacity: 0.9 },
+        ],
+        extendToWaypoints: false,
+        missingRouteTolerance: 0,
+      },
       routeWhileDragging: false,
       addWaypoints: false,
       draggableWaypoints: false,
@@ -286,12 +246,10 @@ function RoutingMachine({
 
     routingControl.on("routesfound", (event) => {
       const route = event.routes[0];
-
       setRouteInfo({
         distanceKm: (route.summary.totalDistance / 1000).toFixed(1),
         durationMin: Math.round(route.summary.totalTime / 60),
       });
-      
       setRouteLoading(false);
       setRouteError("");
       setShouldRoute(false);
@@ -313,47 +271,121 @@ function RoutingMachine({
         routingControlRef.current = null;
       }
     };
-  }, [
-    map,
-    startPosition,
-    targetPosition,
-    shouldRoute,
-    setShouldRoute,
-    setRouteInfo,
-    setRouteError,
-  ]);
+  }, [shouldRoute]);
 
   return null;
 }
 
-export default function Map({ 
+async function fetchWikipediaInfo(placeName) {
+  const searchTerm = placeName.split(",")[0].trim();
+
+  const url =
+    `https://de.wikipedia.org/w/api.php?action=query` +
+    `&prop=extracts&exintro=true&explaintext=true&redirects=1` +
+    `&titles=${encodeURIComponent(searchTerm)}&format=json&origin=*`;
+
+  const response = await fetch(url);
+  const data = await response.json();
+
+  const pages = data.query?.pages;
+  if (!pages) return null;
+
+  const page = Object.values(pages)[0];
+  if (page.missing !== undefined || page.pageid === undefined) return null;
+
+  const extract = page.extract?.trim();
+  if (!extract) return null;
+
+  if (
+    extract.startsWith(searchTerm + " steht für") ||
+    extract.includes("Begriffsklärung")
+  ) {
+    return null;
+  }
+
+  const shortExtract =
+    extract.length > 250 ? extract.slice(0, 250).trimEnd() + " …" : extract;
+
+  return {
+    title: page.title,
+    extract: shortExtract,
+    url: `https://de.wikipedia.org/wiki/${encodeURIComponent(page.title)}`,
+  };
+}
+
+async function fetchPlaceName(lat, lon) {
+  const url =
+    `https://nominatim.openstreetmap.org/reverse?` +
+    `lat=${lat}&lon=${lon}&format=json&addressdetails=1`;
+
+  const response = await fetch(url, {
+    headers: { "Accept-Language": "de" },
+  });
+
+  const data = await response.json();
+
+  return (
+    data.address?.city ||
+    data.address?.town ||
+    data.address?.village ||
+    data.address?.municipality ||
+    data.address?.county ||
+    data.display_name ||
+    "Unbekannter Ort"
+  );
+}
+
+async function fetchCoordinatesForPlace(placeName) {
+  const url =
+    `https://nominatim.openstreetmap.org/search?` +
+    `q=${encodeURIComponent(placeName)}` +
+    `&format=json&limit=1&addressdetails=1`;
+
+  const response = await fetch(url, {
+    headers: { "Accept-Language": "de" },
+  });
+
+  const data = await response.json();
+
+  if (!data || data.length === 0) return null;
+
+  return {
+    lat: Number(data[0].lat),
+    lon: Number(data[0].lon),
+    displayName: data[0].display_name,
+  };
+}
+
+export default function Map({
   searchPlace,
   onSearchError,
   userPosition,
-  setUserPosition,
   targetPosition,
   setTargetPosition,
   shouldRoute,
   setShouldRoute,
   setRouteInfo,
   setRouteError,
-  setRouteLoading, }) {
+  setRouteLoading,
+  routeInfo,
+}) {
   const [placeName, setPlaceName] = useState("");
   const [wikiInfo, setWikiInfo] = useState(null);
   const requestId = useRef(0);
   const markerRef = useRef(null);
 
+  // Popup nach Wikipedia-Laden öffnen
   useEffect(() => {
     if (wikiInfo && wikiInfo !== "loading") {
       markerRef.current?.openPopup();
     }
   }, [wikiInfo]);
 
+  // Pin + Wikipedia beim Standort-Button
   useEffect(() => {
     if (!userPosition) return;
 
     const currentId = ++requestId.current;
-
     setTargetPosition(userPosition);
     setPlaceName("Ort wird geladen...");
     setWikiInfo("loading");
@@ -383,6 +415,13 @@ export default function Map({
     loadLocationInfo();
   }, [userPosition]);
 
+  // Route auto-aktualisieren wenn neues Ziel gewählt und Route bereits aktiv
+  useEffect(() => {
+    if (!targetPosition || !routeInfo) return;
+    setRouteLoading(true);
+    setShouldRoute(true);
+  }, [targetPosition]);
+
   return (
     <div className="map-wrapper">
       <MapContainer
@@ -395,7 +434,6 @@ export default function Map({
           url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>'
         />
-
 
         <FlyToPosition position={userPosition} />
 
@@ -418,9 +456,23 @@ export default function Map({
           setRouteLoading={setRouteLoading}
         />
 
+        {/* Grüner A-Marker an der Startposition (nur wenn Route aktiv) */}
+        {userPosition && routeInfo && (
+          <Marker position={userPosition} icon={startIcon}>
+            <Popup>
+              <strong>Dein Standort</strong>
+              <p style={{ margin: "4px 0 0", fontSize: "0.85em", color: "#64748b" }}>
+                Startpunkt der Route
+              </p>
+            </Popup>
+          </Marker>
+        )}
+
+        {/* Roter B-Marker am Zielort */}
         {targetPosition && (
           <Marker
             position={targetPosition}
+            icon={routeInfo ? targetIcon : undefined}
             ref={markerRef}
             eventHandlers={{
               add: (e) => e.target.openPopup(),
@@ -435,25 +487,21 @@ export default function Map({
                   Wikipedia wird geladen…
                 </p>
               )}
-
               {wikiInfo === "offline" && (
                 <p style={{ margin: "6px 0 0", color: "#f97316", fontSize: "0.85em" }}>
                   Wikipedia ist offline nicht verfügbar.
                 </p>
               )}
-
               {wikiInfo === "not_found" && (
                 <p style={{ margin: "6px 0 0", color: "#64748b", fontSize: "0.85em" }}>
                   Kein Wikipedia-Artikel gefunden.
                 </p>
               )}
-
               {wikiInfo === "error" && (
                 <p style={{ margin: "6px 0 0", color: "#ef4444", fontSize: "0.85em" }}>
                   Wikipedia nicht erreichbar.
                 </p>
               )}
-
               {wikiInfo && typeof wikiInfo === "object" && (
                 <div style={{ marginTop: "6px", fontSize: "0.85em" }}>
                   <p style={{ margin: "0 0 4px" }}>{wikiInfo.extract}</p>

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -265,13 +265,19 @@ function RoutingMachine({
     routingControl.addTo(map);
     routingControlRef.current = routingControl;
 
+    // Kein Cleanup hier — die Route soll nach dem Berechnen sichtbar bleiben.
+    // Cleanup nur beim Unmount (useEffect unten).
+  }, [shouldRoute]);
+
+  // Route nur beim Unmount entfernen
+  useEffect(() => {
     return () => {
       if (routingControlRef.current) {
         map.removeControl(routingControlRef.current);
         routingControlRef.current = null;
       }
     };
-  }, [shouldRoute]);
+  }, [map]);
 
   return null;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -139,25 +139,37 @@ body {
 }
 
 .route-info {
-   margin: 8px 0 0;
-  padding: 8px 12px;
-  background: #e0f2fe;
-  color: #075985;
-  border-radius: 6px;
+  margin: 8px 0 0;
+  padding: 10px 14px;
+  background: linear-gradient(135deg, #dbeafe, #e0f2fe);
+  color: #1e40af;
+  border-radius: 8px;
   font-size: 0.9rem;
+  border-left: 4px solid #3b82f6;
+  line-height: 1.6;
+}
+
+.route-info strong {
+  display: block;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #3b82f6;
+  margin-bottom: 2px;
 }
 
 .route-error {
-  position: absolute;
-  top: 55px;
-  left: 10px;
-  z-index: 1000;
-
+  margin: 6px 0 0;
+  padding: 8px 12px;
   background: #fee2e2;
   color: #b91c1c;
-
-  padding: 8px 12px;
   border-radius: 6px;
-
   font-size: 0.9rem;
+  border-left: 4px solid #ef4444;
+}
+
+/* Leaflet-Routing-Machine Panel komplett ausblenden */
+.leaflet-routing-container,
+.leaflet-routing-container-hide {
+  display: none !important;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -158,6 +158,22 @@ body {
   margin-bottom: 2px;
 }
 
+.route-places {
+  display: block;
+  font-weight: 600;
+  font-size: 0.88rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.route-stats {
+  display: block;
+  font-size: 0.85rem;
+  opacity: 0.85;
+  margin-top: 2px;
+}
+
 .route-error {
   margin: 6px 0 0;
   padding: 8px 12px;


### PR DESCRIPTION
## Summary

- Routing auf Auto umgestellt (OSRM `routed-car`)
- Vollständige Adresse im Routenband (z.B. „Beispielstr. 44, Friedrichshafen") statt nur Stadtname
- Timing-Fix: Banner aktualisiert sich sobald Geocoding fertig ist
- Marker ohne A/B-Beschriftung (grüner Kreis = Start, roter Tropfen = Ziel)
- Routenband zeigt „Dein Standort → Zielort" mit Distanz und Dauer
- Wikipedia-Suche weiterhin mit Stadtname

## Test plan

- [ ] Auf der Karte klicken → Pin erscheint, Popup öffnet mit vollständiger Adresse
- [ ] „Route berechnen" → blaue Linie erscheint, Banner zeigt Start/Ziel/Distanz/Dauer
- [ ] Neues Ziel klicken während Route aktiv → Route aktualisiert sich automatisch
- [ ] „Standort anzeigen" → Pin + Wikipedia-Popup öffnet sich
- [ ] Marker haben kein A/B mehr