### PR TITLE
feat: Optimierungen (#36)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -153,11 +153,10 @@ function App() {
 
               {/* Eigener Startort */}
               <div className="start-row">
-                <span className="start-icon">🚩</span>
                 <input
                   className="start-input"
                   type="text"
-                  placeholder="Startort (leer = aktueller GPS-Standort)"
+                  placeholder="Start auswählen (leer = GPS-Standort)"
                   value={startText}
                   onChange={(e) => setStartText(e.target.value)}
                   onKeyDown={(e) => e.key === "Enter" && handleRouteClick()}
@@ -177,7 +176,7 @@ function App() {
                   onClick={handleRouteClick}
                   disabled={startLoading}
                 >
-                  {startLoading ? "Lade…" : "🗺 Route berechnen"}
+                  {startLoading ? "Lade…" : "Route berechnen"}
                 </Button>
                 <Button
                   outline
@@ -231,6 +230,7 @@ function App() {
               setRouteLoading={setRouteLoading}
               routeInfo={routeInfo}
               routeStartPosition={routeStartPosition}
+              routeStartLabel={startText.trim() || null}
             />
           </div>
         </Page>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
   App as Framework7App,
   View,
@@ -12,6 +12,23 @@ import {
 import Map from "./components/Map";
 import OfflineBanner from "./components/OfflineBanner";
 
+function formatDuration(minutes) {
+  if (minutes < 60) return `${minutes} Min.`;
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return m > 0 ? `${h}h ${m} Min.` : `${h}h`;
+}
+
+async function geocodePlace(text) {
+  const url =
+    `https://nominatim.openstreetmap.org/search?` +
+    `q=${encodeURIComponent(text)}&format=json&limit=1`;
+  const res = await fetch(url, { headers: { "Accept-Language": "de" } });
+  const data = await res.json();
+  if (!data || data.length === 0) return null;
+  return { lat: Number(data[0].lat), lon: Number(data[0].lon) };
+}
+
 function App() {
   const [searchValue, setSearchValue] = useState("");
   const [submittedSearch, setSubmittedSearch] = useState("");
@@ -24,15 +41,19 @@ function App() {
   const [targetPosition, setTargetPosition] = useState(null);
   const [routeLoading, setRouteLoading] = useState(false);
 
+  // Eigener Startort
+  const [startText, setStartText] = useState("");
+  const [routeStartPosition, setRouteStartPosition] = useState(null);
+  const [startError, setStartError] = useState("");
+  const [startLoading, setStartLoading] = useState(false);
+
   const handleSearch = (event) => {
     event?.preventDefault();
-
     const trimmed = searchValue.trim();
     if (!trimmed) {
       setSearchError("Bitte gib einen Ortsnamen ein.");
       return;
     }
-
     setSearchError("");
     setSubmittedSearch(trimmed);
   };
@@ -43,44 +64,64 @@ function App() {
   };
 
   const handleLocateUser = () => {
-  if (!navigator.geolocation) {
-    showLocationError("Geolocation wird von diesem Browser nicht unterstützt.");
-    return;
-  }
-
-  setLocationError("");
-
-  navigator.geolocation.getCurrentPosition(
-    (pos) => {
-      const coords = [pos.coords.latitude, pos.coords.longitude];
-
-      setUserPosition(coords);
-      setLocationError("");
-
-      console.log("Standort über Button aktualisiert:", coords);
-    },
-    (err) => {
-      console.error("Standort konnte nicht geladen werden:", err);
-
-      if (err.code === 1) {
-        showLocationError(
-          "Standortzugriff verweigert. Bitte aktiviere die Standortfreigabe."
-        );
-      } else if (err.code === 2) {
-        showLocationError("Standort konnte nicht ermittelt werden.");
-      } else if (err.code === 3) {
-        showLocationError("Zeitüberschreitung beim Abrufen des Standorts.");
-      } else {
-        showLocationError("Standort konnte nicht geladen werden.");
-      }
-    },
-    {
-      enableHighAccuracy: false,
-      timeout: 10000,
-      maximumAge: 60000,
+    if (!navigator.geolocation) {
+      showLocationError("Geolocation wird von diesem Browser nicht unterstützt.");
+      return;
     }
-  );
-};
+    setLocationError("");
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const coords = [pos.coords.latitude, pos.coords.longitude];
+        setUserPosition(coords);
+        setLocationError("");
+      },
+      (err) => {
+        if (err.code === 1) showLocationError("Standortzugriff verweigert. Bitte aktiviere die Standortfreigabe.");
+        else if (err.code === 2) showLocationError("Standort konnte nicht ermittelt werden.");
+        else if (err.code === 3) showLocationError("Zeitüberschreitung beim Abrufen des Standorts.");
+        else showLocationError("Standort konnte nicht geladen werden.");
+      },
+      { enableHighAccuracy: false, timeout: 10000, maximumAge: 60000 }
+    );
+  };
+
+  const handleRouteClick = async () => {
+    setRouteError("");
+    setRouteInfo(null);
+    setStartError("");
+
+    if (!targetPosition) {
+      setRouteError("Bitte zuerst ein Ziel auswählen.");
+      return;
+    }
+
+    if (startText.trim()) {
+      // Eigener Startort geocodieren
+      setStartLoading(true);
+      try {
+        const result = await geocodePlace(startText.trim());
+        setStartLoading(false);
+        if (!result) {
+          setStartError("Startort nicht gefunden. Bitte genauer eingeben.");
+          return;
+        }
+        setRouteStartPosition([result.lat, result.lon]);
+      } catch {
+        setStartLoading(false);
+        setStartError("Startort konnte nicht geladen werden.");
+        return;
+      }
+    } else {
+      setRouteStartPosition(null);
+      if (!userPosition) {
+        setRouteError("Bitte Standortfreigabe erlauben oder Startort eingeben.");
+        return;
+      }
+    }
+
+    setRouteLoading(true);
+    setShouldRoute(true);
+  };
 
   return (
     <Framework7App name="WebEng2 Map App" theme="auto">
@@ -91,90 +132,88 @@ function App() {
           <Block className="top-content">
             <OfflineBanner />
 
-            <div className="search-location-row">
+            <div className="controls-card">
+              {/* Ziel-Suche */}
               <div className="search-area">
                 <Searchbar
-                  placeholder="Ort suchen"
+                  placeholder="Ziel suchen"
                   value={searchValue}
-                  onInput={(event) => setSearchValue(event.target.value)}
+                  onInput={(e) => setSearchValue(e.target.value)}
                   onSubmit={handleSearch}
                   disableButtonText="Abbrechen"
                 />
-
-                <Button fill  className="search-button" onClick={handleSearch}>
+                <Button fill className="search-button" onClick={handleSearch}>
                   Suchen
                 </Button>
               </div>
 
+              {searchError && (
+                <p className="field-error">{searchError}</p>
+              )}
+
+              {/* Eigener Startort */}
+              <div className="start-row">
+                <span className="start-icon">🚩</span>
+                <input
+                  className="start-input"
+                  type="text"
+                  placeholder="Startort (leer = aktueller GPS-Standort)"
+                  value={startText}
+                  onChange={(e) => setStartText(e.target.value)}
+                  onKeyDown={(e) => e.key === "Enter" && handleRouteClick()}
+                />
+                {startText && (
+                  <button className="start-clear" onClick={() => { setStartText(""); setRouteStartPosition(null); setStartError(""); }}>✕</button>
+                )}
+              </div>
+
+              {startError && <p className="field-error">{startError}</p>}
+
+              {/* Aktions-Buttons */}
               <div className="action-row">
                 <Button
                   fill
-                  small
                   className="route-button"
-                  onClick={() => {
-                    setRouteError("");
-                    setRouteInfo(null);
-
-                    if (!userPosition) {
-                      setRouteError("Bitte Standortfreigabe erlauben.");
-                      setRouteLoading(false);
-                      return;
-                    }
-
-                    if (!targetPosition) {
-                      setRouteError("Bitte zuerst ein Ziel auswählen.");
-                      setRouteLoading(false);
-                      return;
-                    }
-
-                    setRouteLoading(true);
-                    setShouldRoute(true);
-                  }}
+                  onClick={handleRouteClick}
+                  disabled={startLoading}
                 >
-                  Route berechnen
+                  {startLoading ? "Lade…" : "🗺 Route berechnen"}
                 </Button>
-
                 <Button
-                  fill
+                  outline
                   className="location-button"
                   onClick={handleLocateUser}
                 >
-                  📍 Standort anzeigen
+                  📍 Standort
                 </Button>
               </div>
-              
+
+              {locationError && (
+                <p className="location-error">{locationError}</p>
+              )}
+
               {routeLoading && (
-                <p className="route-info">
-                  Route wird berechnet…
-                </p>
+                <p className="route-info-loading">Route wird berechnet…</p>
               )}
 
               {routeInfo && !routeLoading && (
                 <div className="route-info">
-                  <strong>Route</strong>
-                  <span className="route-places">{routeInfo.from} → {routeInfo.to}</span>
-                  <span className="route-stats">{routeInfo.distanceKm} km &nbsp;·&nbsp; {routeInfo.durationMin} Min.</span>
+                  <div className="route-info-header">
+                    <span className="route-label">Route</span>
+                    <span className="route-stats">
+                      {routeInfo.distanceKm} km &nbsp;·&nbsp; {formatDuration(routeInfo.durationMin)}
+                    </span>
+                  </div>
+                  <span className="route-places">
+                    {routeInfo.from} → {routeInfo.to}
+                  </span>
                 </div>
               )}
 
               {routeError && (
-                <p className="route-error">
-                  {routeError}
-                </p>
+                <p className="route-error">{routeError}</p>
               )}
             </div>
-
-            {locationError && (
-              <p className="location-error">
-                {locationError}
-              </p>
-            )}
-
-            {searchError && (
-              <p style={{ color: "#ef4444", marginTop: "8px" }}>
-                {searchError}
-              </p>
-            )}
           </Block>
 
           <div className="map-fill">
@@ -191,6 +230,7 @@ function App() {
               setRouteError={setRouteError}
               setRouteLoading={setRouteLoading}
               routeInfo={routeInfo}
+              routeStartPosition={routeStartPosition}
             />
           </div>
         </Page>

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -172,6 +172,7 @@ function SearchPlaceHandler({
 
 function RoutingMachine({
   startPosition,
+  startPositionOverride,
   targetPosition,
   shouldRoute,
   setShouldRoute,
@@ -186,8 +187,10 @@ function RoutingMachine({
   useEffect(() => {
     if (!shouldRoute) return;
 
-    if (!startPosition) {
-      setRouteError("Bitte Standortfreigabe erlauben.");
+    const effectiveStart = startPositionOverride || startPosition;
+
+    if (!effectiveStart) {
+      setRouteError("Bitte Standortfreigabe erlauben oder Startort eingeben.");
       setRouteInfo(null);
       setShouldRoute(false);
       return;
@@ -208,7 +211,7 @@ function RoutingMachine({
 
     const routingControl = L.Routing.control({
       waypoints: [
-        L.latLng(startPosition[0], startPosition[1]),
+        L.latLng(effectiveStart[0], effectiveStart[1]),
         L.latLng(targetPosition[0], targetPosition[1]),
       ],
       router: L.Routing.osrmv1({
@@ -374,6 +377,7 @@ export default function Map({
   setRouteError,
   setRouteLoading,
   routeInfo,
+  routeStartPosition,
 }) {
   const [placeName, setPlaceName] = useState("");
   const [wikiInfo, setWikiInfo] = useState(null);
@@ -465,6 +469,7 @@ export default function Map({
 
         <RoutingMachine
           startPosition={userPosition}
+          startPositionOverride={routeStartPosition}
           targetPosition={targetPosition}
           shouldRoute={shouldRoute}
           setShouldRoute={setShouldRoute}
@@ -474,11 +479,11 @@ export default function Map({
           targetPlaceName={placeName}
         />
 
-        {/* Grüner A-Marker an der Startposition (nur wenn Route aktiv) */}
-        {userPosition && routeInfo && (
-          <Marker position={userPosition} icon={startIcon}>
+        {/* Grüner Marker an der Startposition (nur wenn Route aktiv) */}
+        {routeInfo && (routeStartPosition || userPosition) && (
+          <Marker position={routeStartPosition || userPosition} icon={startIcon}>
             <Popup>
-              <strong>Dein Standort</strong>
+              <strong>{routeStartPosition ? "Eigener Startort" : "Dein Standort"}</strong>
               <p style={{ margin: "4px 0 0", fontSize: "0.85em", color: "#64748b" }}>
                 Startpunkt der Route
               </p>

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -173,6 +173,7 @@ function SearchPlaceHandler({
 function RoutingMachine({
   startPosition,
   startPositionOverride,
+  startLabel,
   targetPosition,
   shouldRoute,
   setShouldRoute,
@@ -241,7 +242,7 @@ function RoutingMachine({
       setRouteInfo({
         distanceKm: (route.summary.totalDistance / 1000).toFixed(1),
         durationMin: Math.round(route.summary.totalTime / 60),
-        from: "Dein Standort",
+        from: startLabel || "Dein Standort",
         to: targetPlaceName || "Ziel",
       });
       setRouteLoading(false);
@@ -378,6 +379,7 @@ export default function Map({
   setRouteLoading,
   routeInfo,
   routeStartPosition,
+  routeStartLabel,
 }) {
   const [placeName, setPlaceName] = useState("");
   const [wikiInfo, setWikiInfo] = useState(null);
@@ -470,6 +472,7 @@ export default function Map({
         <RoutingMachine
           startPosition={userPosition}
           startPositionOverride={routeStartPosition}
+          startLabel={routeStartLabel}
           targetPosition={targetPosition}
           shouldRoute={shouldRoute}
           setShouldRoute={setShouldRoute}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,15 @@
+/* ── CSS-Variablen & Framework7-Theming ────────────────────── */
+:root {
+  --f7-theme-color: #2563eb;
+  --f7-theme-color-rgb: 37, 99, 235;
+  --f7-navbar-bg-color: #1e40af;
+  --f7-navbar-text-color: #ffffff;
+  --f7-navbar-link-color: rgba(255, 255, 255, 0.85);
+  --f7-navbar-title-font-size: 17px;
+  --f7-navbar-title-font-weight: 700;
+  --f7-safe-area-top: 0px;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -11,11 +23,11 @@ body,
 
 body {
   font-family: Inter, system-ui, sans-serif;
-  background: #f5f7fb;
-  color: #20232a;
+  background: linear-gradient(160deg, #e8f0fe 0%, #f5f7fb 60%, #fafbff 100%);
+  color: #1e293b;
 }
 
-/* Framework7-Grundcontainer */
+/* ── Framework7-Grundcontainer ─────────────────────────────── */
 .framework7-root,
 .views,
 .view,
@@ -23,73 +35,43 @@ body {
   height: 100%;
 }
 
-/* Ganze App-Seite */
+/* ── Seite: kein vertikales Scrollen ───────────────────────── */
 .app-page {
-  height: 100vh;
+  height: 100dvh;
   overflow: hidden;
 }
 
-/* Bereich oberhalb der Karte: Offline-Banner + Suchleiste + Button */
+/* page-content als Flex-Spalte, kein Scroll */
+.app-page .page-content {
+  display: flex !important;
+  flex-direction: column;
+  overflow: hidden !important;
+  padding-bottom: 0 !important;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+}
+
+/* ── Oberer Bereich (Controls) ─────────────────────────────── */
 .top-content {
-  display: flex;
-  gap: 12px;
-  align-items: stretch;
+  flex: 0 0 auto;
+  padding: 8px 12px !important;
+  margin: 0 !important;
 }
 
-/* Karte nimmt den restlichen sichtbaren Platz ein */
-.map-fill {
-  width: 100%;
-  height: calc(100vh - 150px);
-}
-
-/* Äußerer Container in Map.jsx */
-.map-wrapper {
-  width: 100%;
-  height: 100%;
-  position: relative;
-}
-
-/* Leaflet selbst */
-.leaflet-container {
-  width: 100%;
-  height: 100%;
-}
-
-/* Optionaler Link auf der Karte */
-.map-issue-link {
-  position: absolute;
-  left: 12px;
-  bottom: 12px;
-  z-index: 1000;
-  background: white;
-  color: #0645ad;
-  padding: 6px 10px;
-  border-radius: 6px;
-  font-size: 14px;
-  text-decoration: none;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);
-}
-
-/* Offline-Hinweis */
-.offline-banner {
-  background: #fef08a;
-  color: #713f12;
-  text-align: center;
-  padding: 0.6rem 1rem;
-  border-radius: 0.5rem;
-  font-size: 0.9rem;
-  font-weight: 500;
-  margin-bottom: 0.75rem;
-  border: 1px solid #fde047;
-}
-
-.search-location-row {
-  width: 100%;
+/* ── Controls-Card ─────────────────────────────────────────── */
+.controls-card {
+  background: #ffffff;
+  border-radius: 16px;
+  box-shadow:
+    0 4px 24px rgba(37, 99, 235, 0.08),
+    0 1px 6px rgba(0, 0, 0, 0.06);
+  padding: 10px 12px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
 }
 
+/* ── Ziel-Suche ────────────────────────────────────────────── */
 .search-area {
   display: flex;
   gap: 8px;
@@ -102,89 +84,196 @@ body {
 }
 
 .search-button {
-  width: 140px;
+  flex-shrink: 0;
+  width: 90px;
+  font-weight: 600 !important;
 }
 
+/* ── Eigener Startort ──────────────────────────────────────── */
+.start-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: #f8fafc;
+  border: 1.5px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 0 10px;
+  transition: border-color 0.2s;
+}
+
+.start-row:focus-within {
+  border-color: #2563eb;
+  background: #fff;
+}
+
+.start-icon {
+  font-size: 16px;
+  flex-shrink: 0;
+}
+
+.start-input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  padding: 9px 0;
+  font-size: 0.88rem;
+  color: #1e293b;
+  outline: none;
+  min-width: 0;
+}
+
+.start-input::placeholder {
+  color: #94a3b8;
+}
+
+.start-clear {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #94a3b8;
+  font-size: 14px;
+  padding: 4px;
+  line-height: 1;
+  flex-shrink: 0;
+  transition: color 0.15s;
+}
+
+.start-clear:hover {
+  color: #64748b;
+}
+
+/* ── Aktions-Buttons ───────────────────────────────────────── */
 .action-row {
   display: flex;
   gap: 8px;
-  width: 100%;
 }
 
-.route-button{
+.route-button {
   flex: 1;
-  height: auto;
+  font-weight: 600 !important;
+  letter-spacing: 0.01em;
 }
 
 .location-button {
-  flex: 1;
-  height: auto;
+  flex-shrink: 0;
+  width: 120px;
 }
 
-.search-error {
-  color: #ef4444;
-  margin-top: 8px;
+/* ── Fehler-Meldungen ──────────────────────────────────────── */
+.field-error {
+  margin: 0;
+  padding: 4px 2px;
+  color: #dc2626;
+  font-size: 0.82rem;
 }
 
 .location-error {
+  margin: 0;
+  padding: 7px 10px;
   color: #b91c1c;
   background: #fee2e2;
-  padding: 8px 12px;
-  border-radius: 6px;
-  margin-top: 8px;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  border-left: 3px solid #ef4444;
 }
 
-.leaflet-routing-container {
-  display: none;
+.route-error {
+  margin: 0;
+  padding: 7px 10px;
+  background: #fee2e2;
+  color: #b91c1c;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  border-left: 3px solid #ef4444;
+}
+
+/* ── Routeninfo-Banner ─────────────────────────────────────── */
+.route-info-loading {
+  margin: 0;
+  padding: 8px 10px;
+  color: #2563eb;
+  font-size: 0.85rem;
+  text-align: center;
+  animation: pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.5; }
 }
 
 .route-info {
-  margin: 8px 0 0;
-  padding: 10px 14px;
+  padding: 9px 12px;
   background: linear-gradient(135deg, #dbeafe, #e0f2fe);
-  color: #1e40af;
-  border-radius: 8px;
-  font-size: 0.9rem;
-  border-left: 4px solid #3b82f6;
-  line-height: 1.6;
+  border-radius: 10px;
+  border-left: 4px solid #2563eb;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
-.route-info strong {
-  display: block;
-  font-size: 0.8rem;
+.route-info-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.route-label {
+  font-size: 0.75rem;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: #3b82f6;
-  margin-bottom: 2px;
+  letter-spacing: 0.07em;
+  color: #2563eb;
+}
+
+.route-stats {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #1e40af;
 }
 
 .route-places {
-  display: block;
-  font-weight: 600;
-  font-size: 0.88rem;
+  font-size: 0.85rem;
+  color: #1e3a8a;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.route-stats {
-  display: block;
+/* ── Karte füllt restlichen Platz ──────────────────────────── */
+.map-fill {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+}
+
+/* ── Äußerer Map-Wrapper ───────────────────────────────────── */
+.map-wrapper {
+  width: 100%;
+  height: 100%;
+  position: relative;
+}
+
+/* ── Leaflet ───────────────────────────────────────────────── */
+.leaflet-container {
+  width: 100%;
+  height: 100%;
+}
+
+/* ── Offline-Banner ────────────────────────────────────────── */
+.offline-banner {
+  background: #fef9c3;
+  color: #713f12;
+  text-align: center;
+  padding: 6px 12px;
+  border-radius: 10px;
   font-size: 0.85rem;
-  opacity: 0.85;
-  margin-top: 2px;
+  font-weight: 500;
+  margin-bottom: 6px;
+  border: 1px solid #fde047;
 }
 
-.route-error {
-  margin: 6px 0 0;
-  padding: 8px 12px;
-  background: #fee2e2;
-  color: #b91c1c;
-  border-radius: 6px;
-  font-size: 0.9rem;
-  border-left: 4px solid #ef4444;
-}
-
-/* Leaflet-Routing-Machine Panel komplett ausblenden */
+/* ── Leaflet-Routing-Machine Panel ausblenden ──────────────── */
 .leaflet-routing-container,
 .leaflet-routing-container-hide {
   display: none !important;

--- a/src/index.css
+++ b/src/index.css
@@ -91,55 +91,56 @@ body {
 
 /* ── Eigener Startort ──────────────────────────────────────── */
 .start-row {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto;
   align-items: center;
-  gap: 8px;
   background: #f8fafc;
   border: 1.5px solid #e2e8f0;
   border-radius: 10px;
-  padding: 0 10px;
-  transition: border-color 0.2s;
+  overflow: hidden;
+  transition: border-color 0.2s, background 0.2s;
 }
 
 .start-row:focus-within {
   border-color: #2563eb;
-  background: #fff;
-}
-
-.start-icon {
-  font-size: 16px;
-  flex-shrink: 0;
+  background: #ffffff;
 }
 
 .start-input {
-  flex: 1;
+  grid-column: 1;
+  width: 100%;
+  box-sizing: border-box;
   border: none;
   background: transparent;
-  padding: 9px 0;
+  padding: 10px 12px;
   font-size: 0.88rem;
-  color: #1e293b;
+  font-family: inherit;
+  color: #1e293b !important;
+  -webkit-text-fill-color: #1e293b !important;
   outline: none;
-  min-width: 0;
+  -webkit-appearance: none;
+  appearance: none;
 }
 
 .start-input::placeholder {
-  color: #94a3b8;
+  color: #94a3b8 !important;
+  -webkit-text-fill-color: #94a3b8 !important;
 }
 
 .start-clear {
+  grid-column: 2;
+  padding: 10px 12px;
   background: none;
   border: none;
   cursor: pointer;
   color: #94a3b8;
-  font-size: 14px;
-  padding: 4px;
+  font-size: 15px;
   line-height: 1;
-  flex-shrink: 0;
   transition: color 0.15s;
 }
 
 .start-clear:hover {
-  color: #64748b;
+  color: #475569;
 }
 
 /* ── Aktions-Buttons ───────────────────────────────────────── */


### PR DESCRIPTION
## Summary

- Kein vertikales Scrollen: Flexbox-Layout, Karte füllt immer den Restplatz
- Fahrzeit in Stunden ab 60 Min. (z.B. „1h 30 Min.")
- Eigener Startort: Eingabefeld mit Geocoding, X-Button rechts, korrekter Name im Banner
- Design-Overhaul: Controls-Card, Dunkelblau-Navbar, CSS-Variablen, Lade-Puls

## Test plan

- [ ] Kein vertikales Scrollen, Karte füllt den Bildschirm
- [ ] Fahrzeit > 60 Min. → „Xh Y Min."
- [ ] Startort eingeben → Route startet dort, Banner zeigt eingegebenen Namen
- [ ] Startort leer → Route startet vom GPS-Standort
- [ ] X-Button erscheint rechts und löscht das Feld